### PR TITLE
Remove slack from footer and lab page

### DIFF
--- a/views/includes/footer.html
+++ b/views/includes/footer.html
@@ -6,7 +6,6 @@
         <a href='https://www.facebook.com/groups/uclaieee/' target='_blank'><i class='fab fa-facebook-square fa-3x'></i></a>
         <a href='https://www.instagram.com/uclaieee/' target='_blank'><i class='fab fa-instagram fa-3x'></i></a>
         <a href='https://github.com/UCLA-IEEE' target='_blank'><i class='fab fa-github fa-3x'></i></a>
-        <a href='https://uclaieee.slack.com/' target='_blank'><i class='fab fa-slack fa-3x'></i></a>
         <a href='https://discord.gg/yTR6XUS' target='_blank'><i class='fab fa-discord fa-3x'></i></a>
     </div>
 </div>

--- a/views/lab.php
+++ b/views/lab.php
@@ -95,12 +95,6 @@
                     <a href="https://discord.gg/yTR6XUS" target="_blank">https://discord.gg/yTR6XUS</a>
                 </p>
             </div>
-            <div class='resource'>
-                <h2 class='ieee-blue thin'>Slack Workspace</h2>
-                <p class='black'>
-                    <a href='https://slack.com/' target='_blank'>Slack</a> is a team communication application, and is one of our primary means of communication within our organization. Our Slack workspace is free to join to all general members at <a href='https://uclaieee.slack.com/' target='_blank'>https://uclaieee.slack.com/</a>. Within our Slack workspace, you can directly message officers, communicate with fellow project members, and ask if the lab is open.
-                </p>
-            </div>
         </div>
     </div>
 


### PR DESCRIPTION
The IEEE Slack is now deprecated.